### PR TITLE
Add SLAP2 file structure documentation

### DIFF
--- a/docs/SLAP2_experimental_summary_file_structure.md
+++ b/docs/SLAP2_experimental_summary_file_structure.md
@@ -6,8 +6,7 @@ SLAP2 Summary files are MATLAB v7.3 HDF5 files containing processed glutamate im
 
 ## File Format Details
 
-- **Format**: MATLAB v7.3 (HDF5-based)
-- **Typical Size**: 8-10 GB
+- **Format**: MATLAB v7.3 MAT-file (HDF5 schema)
 - **Extension**: `.mat`
 - **Naming**: `Summary-YYMMDD-HHMMSS.mat`
 

--- a/docs/SLAP2_experimental_summary_file_structure.md
+++ b/docs/SLAP2_experimental_summary_file_structure.md
@@ -1,0 +1,169 @@
+# SLAP2 Experimental Summary File Structure Documentation
+
+## Overview
+
+SLAP2 Summary files are MATLAB v7.3 HDF5 files containing processed glutamate imaging data and acquisition metadata. These files store the complete experimental results from the SLAP2 glutamate imaging pipeline.
+
+## File Format Details
+
+- **Format**: MATLAB v7.3 (HDF5-based)
+- **Typical Size**: 8-10 GB
+- **Extension**: `.mat`
+- **Naming**: `Summary-YYMMDD-HHMMSS.mat`
+
+## File Structure Hierarchy
+
+SLAP2 Summary files contain multiple top-level structures:
+
+```
+Summary-YYMMDD-HHMMSS.mat
+├── exptSummary/                    # Main processed experimental data
+│   ├── E (cell array)             # Trial data
+│   ├── params (struct)            # Processing parameters  
+│   ├── trialTable (struct)        # Trial organization
+│   └── [other analysis results]
+└── #refs#/                         # MATLAB object references (internal)
+└── #subsystem#/                    # MATLAB metadata (internal)
+```
+
+**Note**: Summary files contain only processed experimental data. Original acquisition parameters (like `acqDuration_s`, `aomVoltage`, etc.) are stored in separate `.meta` files from the original SLAP2 acquisition.
+
+## ExperimentSummary Structure (exptSummary)
+
+The main data structure containing all processed experimental results.
+
+### Top-Level Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| **Core Data Fields** | | |
+| `E` | Cell Array (2×155) | Main experimental data - traces and analysis for each FOV×trial |
+| `meanIM` | Cell Array (2×1) | Average images across all trials for each FOV |
+| `actIM` | Cell Array (2×1) | Activity images showing identified synaptic sites for each FOV |
+| `params` | Structure | Processing parameters and settings used |
+| **Trial Organization** | | |
+| `trialTable` | Structure | Trial metadata, filenames, timing, and organization |
+| `Z` | Array (2×1) | Z-positions for each FOV in micrometers |
+| **Additional Analysis Data** | | |
+| `userROIs` | Cell Array (2×1) | User-defined regions of interest for each FOV |
+| `aData` | Cell Array (2×155) | Additional analysis data per trial |
+| `peaks` | Cell Array (2×1) | Peak detection results for each FOV |
+| **Per-Trial Images** | | |
+| `perTrialActIMs` | Cell Array (2×1) | Activity images for each individual trial |
+| `perTrialActIMsAligned` | Cell Array (2×1) | Aligned activity images for each trial |
+| `perTrialMeanIMs` | Cell Array (2×1) | Mean images for each individual trial |
+| `perTrialMeanIMsAligned` | Cell Array (2×1) | Aligned mean images for each trial |
+| `perTrialAlignmentOffsets` | Cell Array (2×1) | Alignment offset data for each trial |
+| **Metadata** | | |
+| `dr` | String Array (94×1) | Directory path information |
+
+## E{} Cell Array Structure (Main Data)
+
+Each `exptSummary.E{fov, trial}` contains processed data for one field of view in one trial.
+
+### Data Fields in Each E{} Cell
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dF` | Structure | Baseline-subtracted fluorescence signals |
+| `F0` | Array (e.g., 4002×120) | Fluorescence baseline estimates |
+| `dFF` | Structure | Fractional fluorescence changes (dF/F0) |
+| `ROIs` | Structure | User-defined region of interest signals |
+| `footprints` | Array | Spatial footprints of identified synaptic sources |
+| `global` | Structure | Global experiment parameters |
+| `noiseEst` | Array | Noise estimation data |
+| `discardFrames` | Array | Frames marked for exclusion from analysis |
+
+### Signal Processing Subfields
+
+The `dF`, `dFF`, and `ROIs` structures contain subfields with different temporal processing methods:
+
+| Subfield | Description |
+|----------|-------------|
+| `ls` | Least Squares - no temporal prior or constraints |
+| `matchFilt` | Matched Filter - optimal for event detection |
+| `nonneg` | Non-negative - mild nonnegativity constraint |
+| `spikes` | Spike Detection - sharp event onsets, removes indicator kinetics |
+| `denoised` | Denoised - strong temporal prior, smooth signals |
+
+## Parameters Structure (params)
+
+Processing parameters used to generate the data:
+
+| Parameter | Example Value | Description |
+|-----------|---------------|-------------|
+| `analyzeHz` | 200.0 | Analysis sampling rate (Hz) |
+| `alignHz` | 80.0 | Alignment sampling rate (Hz) |
+| `sigma_px` | 1.33 | Expected synaptic source size (pixels) |
+| `tau_s` | 0.05 | Signal rise time constant (seconds) |
+| `tau_full` | 10.0 | Full signal decay time (seconds) |
+| `dXY` | 4.0 | Spatial downsampling factor |
+| `nParallelWorkers` | 8.0 | Number of parallel processing workers |
+| `sz` | [323, 832] | Image dimensions (pixels) |
+| `maxSynapseDensity` | 0.01 | Maximum allowed synapse density |
+| `baselineWindow_Glu_s` | 4.0 | Baseline estimation window (seconds) |
+| `denoiseWindow_s` | 0.25 | Denoising window size (seconds) |
+| `motionThresh` | 2.5 | Motion detection threshold |
+| `nanThresh` | 0.25 | NaN tolerance threshold |
+| `sparseFac` | 0.05 | Sparsity factor for matrix factorization |
+
+## Trial Table Structure (trialTable)
+
+Organization and metadata for all trials:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epoch` | Array (155×1) | Epoch number for each trial |
+| `filename` | Cell Array (155×2) | Source filenames for each trial and FOV |
+| `firstLine` | Array (155×2) | First scan line number for each trial |
+| `lastLine` | Array (155×2) | Last scan line number for each trial |
+| `fnAdata` | Cell Array (155×2) | Analysis data filenames |
+| `fnRaw` | Cell Array (155×2) | Raw data filenames |
+| `fnRegDS` | Cell Array (155×2) | Registered downsampled filenames |
+| `trialStartTimeInferred` | Array (155×1) | Inferred trial start times |
+| `trialEndTimeFromPC` | Array (155×1) | Trial end times from PC clock |
+| `trueTrialIx` | Array (155×1) | True trial indices |
+| `refStack` | Cell Array (2×1) | Reference stack information for each FOV |
+| `alignParams` | Structure | Alignment parameters used |
+
+### Alignment Parameters (trialTable.alignParams)
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `alignHz` | 80.0 | Alignment sampling rate |
+| `alpha` | 0.005 | Alignment regularization parameter |
+| `clipShift` | 5.0 | Maximum shift clipping value |
+| `includeIntegrationROIs` | false | Include integration ROIs in alignment |
+| `isReVolt` | false | Whether using ReVolt system |
+| `maxshift` | 50.0 | Maximum allowed shift (pixels) |
+| `nWorkers` | 16.0 | Number of alignment workers |
+| `overwriteExisting` | false | Whether to overwrite existing files |
+| `refStackTemplate` | false | Use reference stack as template |
+
+## Additional Processing Parameters (params)
+
+The `params` structure contains processing parameters used to generate the Summary file. Based on actual file analysis:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `activityChannel` | 1.0 | Channel used for activity detection |
+| `alignHz` | 80.0 | Alignment sampling rate (Hz) |
+| `analyzeHz` | 200.0 | Analysis sampling rate (Hz) |
+| `baselineWindow_Ca_s` | 4.0 | Calcium baseline estimation window (seconds) |
+| `baselineWindow_Glu_s` | 4.0 | Glutamate baseline estimation window (seconds) |
+| `dXY` | 4.0 | Spatial downsampling factor |
+| `denoiseWindow_s` | 0.25 | Denoising window size (seconds) |
+| `discardInitial_s` | 0.1 | Initial time to discard (seconds) |
+| `drawUserRois` | true | Whether user ROIs were drawn |
+| `maxSynapseDensity` | 0.01 | Maximum allowed synapse density |
+| `microscope` | [array] | Microscope configuration parameters |
+| `motionThresh` | 2.5 | Motion detection threshold |
+| `nParallelWorkers` | 8.0 | Number of parallel processing workers |
+| `nanThresh` | 0.25 | NaN tolerance threshold |
+| `nmfIter` | 5.0 | Number of NMF iterations |
+| `numChannels` | 1.0 | Number of acquisition channels |
+| `sigma_px` | 1.33 | Expected synaptic source size (pixels) |
+| `sparseFac` | 0.05 | Sparsity factor for matrix factorization |
+| `sz` | [323, 832] | Image dimensions (pixels) |
+| `tau_full` | 10.0 | Full signal decay time (seconds) |
+| `tau_s` | 0.05 | Signal rise time constant (seconds) |

--- a/docs/SLAP2_meta_file_structure.md
+++ b/docs/SLAP2_meta_file_structure.md
@@ -1,0 +1,148 @@
+# SLAP2 .meta File Structure Documentation
+
+## Overview
+
+SLAP2 `.meta` files are MATLAB v7.3 HDF5 files that contain acquisition metadata and hardware configuration parameters for SLAP2 experiments. These files are generated during data acquisition and store essential information about the experimental setup, hardware settings, and acquisition parameters.
+
+## File Format
+
+- **Format**: MATLAB v7.3 MAT-file (HDF5 schema)
+- **Platform**: PCWIN64
+- **Extension**: `.meta`
+- **Example**: `acquisition_20250508_145020_DMD1.meta`
+
+## File Structure Hierarchy
+
+```
+Root Level
+├── #refs# (Group) - Internal MATLAB object references
+├── #subsystem# (Group) - MATLAB subsystem information
+├── AcquisitionContainer (Group) - Main acquisition configuration
+├── machineConfiguration (Group) - Hardware configuration details
+└── [Direct Parameters] - Core acquisition and hardware settings
+```
+
+## Root Level Parameters
+
+### Core Acquisition Parameters
+
+| Parameter | Type | Description | Example Value |
+|-----------|------|-------------|---------------|
+| `acqDuration_s` | float64 | Total acquisition duration in seconds | `99999999.` |
+| `acqDurationCycles` | float64 (2×1) | Duration in acquisition cycles | `[4.2949673e+09, 4.2949673e+09]` |
+| `acquisitionPathIdx` | float64 | Index of the acquisition path | `1.` |
+| `acquisitionPathName` | uint16 array | Name of acquisition path (encoded) | `"Path1"` |
+| `linePeriod_s` | float64 | Time period per scan line in seconds | `9.35745477e-05` |
+| `samplesPerLine` | float64 | Number of samples per scan line | `9261.` |
+| `fpgaTimeReference` | uint32 (1×6) | FPGA timing reference array | `[3707764736, 2, 1, 1, 1, 1]` |
+
+### Hardware Settings
+
+| Parameter | Type | Description | Example Value |
+|-----------|------|-------------|---------------|
+| `aomActive` | uint8 | AOM (Acousto-Optic Modulator) active state | `1` (enabled) |
+| `aomVoltage` | float64 | AOM voltage setting | `0.` |
+| `channelsSave` | float64 | Number of channels to save | `1.` |
+| `enableStack` | float64 | Z-stack acquisition enabled | `0.` (disabled) |
+| `remoteFocusPosition_um` | float32 | Remote focus position in micrometers | `56.75` |
+
+### DMD (Digital Micromirror Device) Parameters
+
+| Parameter | Type | Description | Example Value |
+|-----------|------|-------------|---------------|
+| `dmdPixelsPerColumn` | float64 | Number of DMD pixels per column | `800.` |
+| `dmdPixelsPerRow` | float64 | Number of DMD pixels per row | `1280.` |
+
+## AcquisitionContainer Group
+
+Contains detailed acquisition planning and scanning parameters:
+
+### Sub-groups:
+- **AcquisitionPlan**: Acquisition sequence planning
+- **DmdPatternSequence**: DMD pattern configurations
+- **ParsePlan**: Data parsing configuration
+  - `acqParsePlan`: ROI and pixel mapping
+  - `isSimpleRaster`: Raster scan mode flag
+  - `lineRateHz`: Line scan rate (e.g., `10686.66699219`)
+  - `linesPerCycle`: Lines per acquisition cycle
+  - `pixPerLine`: Pixels per line
+  - `rasterOffsetXY`: Raster offset coordinates
+  - `rasterSizeXY`: Raster scan dimensions
+- **ROIs**: Region of Interest definitions
+- **ScannerParameters**: Scanner configuration
+  - `fovSize`: Field of view dimensions
+  - `lineShear`: Line shear correction values
+  - `pixelDilationXY`: Pixel dilation parameters
+
+## machineConfiguration Group
+
+Contains comprehensive hardware configuration with three main arrays:
+- **configuration**: Hardware component configurations
+- **instanceClass**: Component class definitions  
+- **instanceName**: Component instance names
+
+Each array contains 18 object references corresponding to different hardware components including:
+- Acquisition paths
+- Laser systems
+- DMD devices
+- Scanner components
+- Detection systems
+- Motion control hardware
+
+## Hardware Component Categories
+
+### Imaging Components
+- **Acquisition Paths**: `Path1`, `Path2` (multi-channel imaging)
+- **DMD Systems**: `DMD1`, `DMD2` (spatial light modulation)
+- **Remote Focus**: Piezo-based axial positioning
+
+### Laser and Optics
+- **AOM Control**: Acousto-optic modulation
+- **Laser Clock**: Timing synchronization
+- **Pockels Cell**: Fast laser modulation
+- **Power Control**: Laser power management
+
+### Scanning Systems
+- **Polygonal Scanner**: High-speed line scanning
+- **Scanner Control**: Speed and synchronization
+- **Motion Detection**: Real-time motion tracking
+
+### Data Acquisition
+- **DAQ Systems**: Multi-channel data acquisition
+- **Timing Control**: Trigger and clock management
+- **Digital I/O**: Control signal routing
+
+## Key Acquisition Parameters Summary
+
+```yaml
+Timing:
+  - acqDuration_s: Total acquisition time
+  - linePeriod_s: Line scan period
+  - samplesPerLine: Samples per scan line
+
+Spatial:
+  - dmdPixelsPerRow: 1280 pixels
+  - dmdPixelsPerColumn: 800 pixels  
+  - remoteFocusPosition_um: Z-position
+
+Hardware:
+  - aomVoltage: Laser modulation
+  - channelsSave: Active channels
+  - acquisitionPathName: Detection path
+```
+
+## Usage Notes
+
+1. **File Access**: Requires HDF5 readers (h5py, scipy.io with HDF5 support)
+2. **Encoding**: String parameters stored as uint16 arrays
+3. **References**: Complex objects stored in `#refs#` group with reference pointers
+4. **Compatibility**: MATLAB v7.3 format ensures cross-platform compatibility
+5. **Validation**: Critical for experiment reproducibility and data provenance
+
+## Related Files
+
+- **Summary Files**: Processed data with experiment results (`*_Summary.mat`)
+- **Raw Data**: Acquisition data files (various formats)
+- **Session Files**: Experiment session metadata (`session.json`)
+
+This documentation provides the essential structure and parameters needed to understand SLAP2 `.meta` files for experiment analysis and data processing workflows.

--- a/docs/SLAP2_meta_file_structure.md
+++ b/docs/SLAP2_meta_file_structure.md
@@ -1,33 +1,25 @@
-# SLAP2 .meta File Structure Documentation
+# SLAP2 Meta File Structure
 
-## Overview
-
-SLAP2 `.meta` files are MATLAB v7.3 HDF5 files that contain acquisition metadata and hardware configuration parameters for SLAP2 experiments. These files are generated during data acquisition and store essential information about the experimental setup, hardware settings, and acquisition parameters.
+This document describes the structure and contents of SLAP2 `.meta` files. These are MATLAB v7.3 HDF5 files that contain acquisition metadata and hardware configuration settings for SLAP2 experiments.
 
 ## File Format
 
-- **Format**: MATLAB v7.3 MAT-file (HDF5 schema)
-- **Platform**: PCWIN64
+- **Format**: MATLAB v7.3 MAT-file (HDF5)
 - **Extension**: `.meta`
-- **Example**: `acquisition_20250508_145020_DMD1.meta`
+- **Typical size**: ~800 KB
+- **Platform**: PCWIN64
 
-## File Structure Hierarchy
+## Overview
 
-```
-Root Level
-├── #refs# (Group) - Internal MATLAB object references
-├── #subsystem# (Group) - MATLAB subsystem information
-├── AcquisitionContainer (Group) - Main acquisition configuration
-├── machineConfiguration (Group) - Hardware configuration details
-└── [Direct Parameters] - Core acquisition and hardware settings
-```
+The `.meta` file stores acquisition parameters, hardware settings, and configuration information for each SLAP2 experiment. The file is structured as an HDF5 file with nested groups and datasets containing various acquisition and hardware parameters.
 
-## Root Level Parameters
+## Parameter Reference
 
-### Core Acquisition Parameters
+The `.meta` file contains the following root-level parameters:
 
-| Parameter | Type | Description | Example Value |
+| Parameter Name | Data Type | Description | Example Value |
 |-----------|------|-------------|---------------|
+| **Acquisition Parameters** | | | |
 | `acqDuration_s` | float64 | Total acquisition duration in seconds | `99999999.` |
 | `acqDurationCycles` | float64 (2×1) | Duration in acquisition cycles | `[4.2949673e+09, 4.2949673e+09]` |
 | `acquisitionPathIdx` | float64 | Index of the acquisition path | `1.` |
@@ -35,114 +27,91 @@ Root Level
 | `linePeriod_s` | float64 | Time period per scan line in seconds | `9.35745477e-05` |
 | `samplesPerLine` | float64 | Number of samples per scan line | `9261.` |
 | `fpgaTimeReference` | uint32 (1×6) | FPGA timing reference array | `[3707764736, 2, 1, 1, 1, 1]` |
-
-### Hardware Settings
-
-| Parameter | Type | Description | Example Value |
-|-----------|------|-------------|---------------|
+| **Hardware Control** | | | |
 | `aomActive` | uint8 | AOM (Acousto-Optic Modulator) active state | `1` (enabled) |
 | `aomVoltage` | float64 | AOM voltage setting | `0.` |
 | `channelsSave` | float64 | Number of channels to save | `1.` |
 | `enableStack` | float64 | Z-stack acquisition enabled | `0.` (disabled) |
 | `remoteFocusPosition_um` | float32 | Remote focus position in micrometers | `56.75` |
-
-### DMD (Digital Micromirror Device) Parameters
-
-| Parameter | Type | Description | Example Value |
-|-----------|------|-------------|---------------|
+| **DMD Parameters** | | | |
 | `dmdPixelsPerColumn` | float64 | Number of DMD pixels per column | `800.` |
 | `dmdPixelsPerRow` | float64 | Number of DMD pixels per row | `1280.` |
+| **Complex Data Structures** | | | |
+| `AcquisitionContainer` | Group | Main acquisition configuration and ROI definitions | Complex nested structure |
+| `machineConfiguration` | Group | Hardware configuration details | Complex nested structure |
 
-## AcquisitionContainer Group
+## Notes
 
-Contains detailed acquisition planning and scanning parameters:
+- The file contains many additional internal MATLAB references in the `#refs#` and `#subsystem#` groups
+- Detailed hardware configuration parameters are stored within the `machineConfiguration` group
+- ROI definitions and acquisition plans are contained within the `AcquisitionContainer` group
+- All timing and acquisition parameters are precisely stored for experiment reproducibility
 
-### Sub-groups:
-- **AcquisitionPlan**: Acquisition sequence planning
-- **DmdPatternSequence**: DMD pattern configurations
-- **ParsePlan**: Data parsing configuration
-  - `acqParsePlan`: ROI and pixel mapping
-  - `isSimpleRaster`: Raster scan mode flag
-  - `lineRateHz`: Line scan rate (e.g., `10686.66699219`)
-  - `linesPerCycle`: Lines per acquisition cycle
-  - `pixPerLine`: Pixels per line
-  - `rasterOffsetXY`: Raster offset coordinates
-  - `rasterSizeXY`: Raster scan dimensions
-- **ROIs**: Region of Interest definitions
-- **ScannerParameters**: Scanner configuration
-  - `fovSize`: Field of view dimensions
-  - `lineShear`: Line shear correction values
-  - `pixelDilationXY`: Pixel dilation parameters
+## AcquisitionContainer Sub-fields
 
-## machineConfiguration Group
+The `AcquisitionContainer` group contains detailed acquisition configuration:
 
-Contains comprehensive hardware configuration with three main arrays:
-- **configuration**: Hardware component configurations
-- **instanceClass**: Component class definitions  
-- **instanceName**: Component instance names
+| Sub-field | Type | Description |
+|-----------|------|-------------|
+| **Acquisition Planning** | | |
+| `AcquisitionPlan` | Dataset (2,) uint64 | Acquisition sequence planning references |
+| `DmdPatternSequence` | Dataset (2,) uint64 | DMD pattern sequence references |
+| **Parse Configuration** | | |
+| `ParsePlan` | Group | Data parsing and ROI configuration |
+| `ParsePlan/acqParsePlan` | Group | Acquisition parsing plan with ROI mappings |
+| `ParsePlan/isSimpleRaster` | uint8 | Simple raster scan mode flag |
+| `ParsePlan/lineRateHz` | float64 | Line scan rate in Hz (e.g., `10686.66699219`) |
+| `ParsePlan/linesPerCycle` | uint64 | Lines per acquisition cycle |
+| `ParsePlan/linesPerFrame` | uint32 | Lines per frame |
+| `ParsePlan/pixPerLine` | uint32 | Pixels per line |
+| `ParsePlan/rasterOffsetXY` | uint32 (2×1) | Raster offset coordinates |
+| `ParsePlan/rasterSizeXY` | uint32 (2×1) | Raster scan dimensions |
+| `ParsePlan/zs` | float32 | Z-position |
+| **ROI and Scanner Configuration** | | |
+| `ROIs` | Group | Region of interest definitions |
+| `ROIs/rois` | object (4×1) | ROI object references |
+| `ScannerParameters` | Group | Scanner configuration parameters |
+| `ScannerParameters/fovSize` | float64 (2×1) | Field of view size |
+| `ScannerParameters/lineRateHz` | float32 | Line scan rate |
+| `ScannerParameters/lineShear` | float32 (1×800) | Line shear correction values |
+| `ScannerParameters/maxDmdPatterns` | float64 | Maximum DMD patterns |
+| `ScannerParameters/pixelDilationXY` | float64 (2×1) | Pixel dilation parameters |
 
-Each array contains 18 object references corresponding to different hardware components including:
-- Acquisition paths
-- Laser systems
-- DMD devices
-- Scanner components
-- Detection systems
-- Motion control hardware
+## machineConfiguration Sub-fields
 
-## Hardware Component Categories
+The `machineConfiguration` group contains hardware component configurations:
 
-### Imaging Components
-- **Acquisition Paths**: `Path1`, `Path2` (multi-channel imaging)
-- **DMD Systems**: `DMD1`, `DMD2` (spatial light modulation)
-- **Remote Focus**: Piezo-based axial positioning
+| Sub-field | Type | Description |
+|-----------|------|-------------|
+| `configuration` | object (1×18) | Hardware component configuration array |
+| `instanceClass` | object (1×18) | Component class definitions |
+| `instanceName` | object (1×18) | Component instance names |
 
-### Laser and Optics
-- **AOM Control**: Acousto-optic modulation
-- **Laser Clock**: Timing synchronization
-- **Pockels Cell**: Fast laser modulation
-- **Power Control**: Laser power management
+### What "18 total" means
 
-### Scanning Systems
-- **Polygonal Scanner**: High-speed line scanning
-- **Scanner Control**: Speed and synchronization
-- **Motion Detection**: Real-time motion tracking
+Each of the three arrays (`configuration`, `instanceClass`, `instanceName`) contains **18 object references**. These references point to detailed configuration data stored elsewhere in the file (in the `#refs#` group). 
 
-### Data Acquisition
-- **DAQ Systems**: Multi-channel data acquisition
-- **Timing Control**: Trigger and clock management
-- **Digital I/O**: Control signal routing
+The 18 hardware components configured in this SLAP2 system include:
+- **2 Acquisition Paths** (Path1, Path2)
+- **2 DMD devices** (DMD1, DMD2) 
+- **2 Remote focus piezo axes** (Axis 1, Axis 2)
+- **Various laser control components** (AOM, laser clock, Pockels cells)
+- **Scanner system** (polygonal scanner with control channels)
+- **Detection systems** (photodiodes, digitizers)
+- **Motion control hardware** (motor stages)
+- **Data acquisition hardware** (DAQ channels)
 
-## Key Acquisition Parameters Summary
+## Understanding the #refs# Group
 
-```yaml
-Timing:
-  - acqDuration_s: Total acquisition time
-  - linePeriod_s: Line scan period
-  - samplesPerLine: Samples per scan line
+The `#refs#` group is a special MATLAB internal structure used in HDF5-based MAT files (v7.3). It serves as a **reference storage system** for complex MATLAB objects.
 
-Spatial:
-  - dmdPixelsPerRow: 1280 pixels
-  - dmdPixelsPerColumn: 800 pixels  
-  - remoteFocusPosition_um: Z-position
+**For most users and analysis pipelines, you do NOT need to access or document the contents of `#refs#`.**
 
-Hardware:
-  - aomVoltage: Laser modulation
-  - channelsSave: Active channels
-  - acquisitionPathName: Detection path
-```
+## Usage
 
-## Usage Notes
+These files can be read using:
+- MATLAB: `load('filename.meta', '-mat')`
+- Python: `h5py.File('filename.meta', 'r')`
+- HDF5 tools: Any HDF5-compatible reader
 
-1. **File Access**: Requires HDF5 readers (h5py, scipy.io with HDF5 support)
-2. **Encoding**: String parameters stored as uint16 arrays
-3. **References**: Complex objects stored in `#refs#` group with reference pointers
-4. **Compatibility**: MATLAB v7.3 format ensures cross-platform compatibility
-5. **Validation**: Critical for experiment reproducibility and data provenance
-
-## Related Files
-
-- **Summary Files**: Processed data with experiment results (`*_Summary.mat`)
-- **Raw Data**: Acquisition data files (various formats)
-- **Session Files**: Experiment session metadata (`session.json`)
-
-This documentation provides the essential structure and parameters needed to understand SLAP2 `.meta` files for experiment analysis and data processing workflows.
+For analysis pipelines, focus on the root-level parameters listed above, as they contain the essential acquisition metadata needed for data processing.


### PR DESCRIPTION
This PR proposes the addition of 2 files. 

One file to document .mat experiment summary file used by downstream analysis. 
One file to document .meta  file that are packaged with every raw data assets of slap2. 

Those markdown are intended to facilitate metadata parsing for AIND .json generation. 

There were semi-AI generated with some assistance  